### PR TITLE
Correccion menor en pom.xml

### DIFF
--- a/apaman-backend/pom.xml
+++ b/apaman-backend/pom.xml
@@ -28,6 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<lombok.version>1.18.38</lombok.version>
 	</properties>
 
 	<repositories>
@@ -81,7 +82,6 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.38</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
- Se agrego en "properties" del pom.xml la versión de "Lombok" para evitar el error por sobrescribir la configuración de "SpringBoot" directamente en "dependencies".